### PR TITLE
perlbrew.fish typo

### DIFF
--- a/fish/perlbrew.fish
+++ b/fish/perlbrew.fish
@@ -113,7 +113,7 @@ if test -z "$PERLBREW_ROOT"
     set -x PERLBREW_ROOT "$HOME/perl5/perlbrew"
 end
 
-if test -x "$PERLBREW_HOME" 
+if test -z "$PERLBREW_HOME" 
     set -x PERLBREW_HOME "$HOME/.perlbrew"
 end
 


### PR DESCRIPTION
Hi, little typo here --

-z not -x
Thanks for perlbrew.fish (and drawing my attention to a different shell)

-Brian
